### PR TITLE
DVD検出時に/Volumes/MobileBackupsを無視するよう修正

### DIFF
--- a/lib/musical/dvd.rb
+++ b/lib/musical/dvd.rb
@@ -10,7 +10,7 @@ module Musical
         file_system = info[0]
         capacity = info[1]
         mounted = info[2]
-        if capacity == "100%" && mounted.include?("/Volumes")
+        if capacity == "100%" && mounted.include?("/Volumes") && !(mounted.include?("MobileBackups"))
           candidates << mounted
         end
       end


### PR DESCRIPTION
dvd.rbのDVD.detectで/Volumes/MobileBackupsを先に検出してしまうとうまく動作しないため、
/Volumes/MobileBackupsを無視するよう修正しました。よろしくお願いいたします。
