### PR TITLE
Change for when there are more than one vob files.

### DIFF
--- a/lib/musical/dvd.rb
+++ b/lib/musical/dvd.rb
@@ -80,9 +80,9 @@ module Musical
           pbar.inc
           # moved file
           vob_path = `find '#{ripped_dir_base}_#{title_index}_#{chapter}' -name "*.VOB"`.chomp
-          vob_path.split.each{|vob|
+          vob_path.split.each do |vob|
             FileUtils.mv vob, "#{saved_dir}/chapter_#{chapter}.VOB"
-          }
+          end
           FileUtils.rm_rf "#{ripped_dir_base}_#{title_index}_#{chapter}"
         end
       end


### PR DESCRIPTION
rip_by_chapter メソッド内で find で vob ファイルのパスを取得していますが，ここで複数の vob ファイルが存在する場合があり，その場合 vob_path には複数のファイル名がつながった文字列が入ってしまいエラーとなっていましたので修正してみました．
